### PR TITLE
[readme] Use gradlew script to bootstrap gradle on Unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Navigate to the [Gradle](http://www.gradle.org/) project (e.g., `path/to/BowlerS
     
     git submodule update
     
-    gradle assemble
+    ./gradlew assemble
     
     java -jar build/libs/BowlerStudio.jar
     


### PR DESCRIPTION
Since GitHub made it really difficult to comment on a rich preview, I am filing this more as an RFC.

`gradle assemble` doesn't seem to be the right command on either of my linux boxes, so I was wondering if this is a better approach. Or should system gradle be expected?