### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/neuronrobotics/bowlerstudio/GistHelper.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/GistHelper.java
@@ -17,6 +17,9 @@ import java.net.URL;
 
 public class GistHelper
 {
+    private GistHelper() {
+    }
+
     public static void createNewGist(String filename, String description, boolean isPublic)
     {
         //TODO: Perhaps this method should throw GitAPIException and IOException

--- a/src/main/java/com/neuronrobotics/bowlerstudio/TestServer.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/TestServer.java
@@ -20,6 +20,9 @@ import com.neuronrobotics.sdk.network.UDPBowlerConnection;
 
 public class TestServer {
 
+	private TestServer() {
+	}
+
 	public static void main(String[] args) throws Exception {
 			class SampleBowlerServer extends BowlerAbstractServer {
 				BowlerAbstractDeviceServerNamespace ns = new BowlerAbstractDeviceServerNamespace(

--- a/src/main/java/com/neuronrobotics/bowlerstudio/assets/AssetFactory.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/assets/AssetFactory.java
@@ -37,6 +37,10 @@ public class AssetFactory {
 			}
 
 	}
+
+	private AssetFactory() {
+	}
+
 	public static Image loadAsset(String file ) throws Exception{
 		
 		if(cache.get(file)==null){

--- a/src/main/java/com/neuronrobotics/bowlerstudio/creature/MobleBaseMenueFactory.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/creature/MobleBaseMenueFactory.java
@@ -56,6 +56,9 @@ import com.neuronrobotics.sdk.util.ThreadUtil;
 
 public class MobleBaseMenueFactory {
 
+	private MobleBaseMenueFactory() {
+	}
+
 	@SuppressWarnings("unchecked")
 	public static void load(MobileBase device, TreeView<String> view, TreeItem<String> rootItem,
 			HashMap<TreeItem<String>, Runnable> callbackMapForTreeitems,

--- a/src/main/java/com/neuronrobotics/bowlerstudio/twod/TwoDCadFactory.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/twod/TwoDCadFactory.java
@@ -33,8 +33,11 @@ import java.awt.geom.PathIterator;
 
 
 public class TwoDCadFactory {
-	
-	public static ArrayList<Polygon> pointsFromString(Font font,String text){
+
+	private TwoDCadFactory() {
+	}
+
+	public static ArrayList<Polygon> pointsFromString(Font font, String text){
 		ArrayList<Polygon> sections = new ArrayList<>();
 		ArrayList<Vector3d> points = new ArrayList<>();
 		FontRenderContext frc = new FontRenderContext(null,(boolean)true,(boolean)true);

--- a/src/main/java/com/neuronrobotics/bowlerstudio/utils/BowlerStudioResourceFactory.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/utils/BowlerStudioResourceFactory.java
@@ -33,7 +33,10 @@ public class BowlerStudioResourceFactory {
 
 		
 	}
-	
+
+	private BowlerStudioResourceFactory() {
+	}
+
 	public static FXMLLoader getLoader(int channelIndex){
 		return fxmlLoaders.get(channelIndex);
 	}

--- a/src/main/java/com/neuronrobotics/graphing/CSVWriter.java
+++ b/src/main/java/com/neuronrobotics/graphing/CSVWriter.java
@@ -11,7 +11,10 @@ import javax.swing.JOptionPane;
 import com.neuronrobotics.sdk.common.SDKInfo;
 
 public class CSVWriter {
-	public static void WriteToCSV(ArrayList<GraphDataElement> dataTable,String filename) {
+	private CSVWriter() {
+	}
+
+	public static void WriteToCSV(ArrayList<GraphDataElement> dataTable, String filename) {
 		String out = "";
 		synchronized(dataTable){
 			for(int j =0;j< dataTable.size();j++) {

--- a/src/main/java/com/neuronrobotics/nrconsole/util/FileSelectionFactory.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/util/FileSelectionFactory.java
@@ -12,7 +12,10 @@ import com.neuronrobotics.sdk.util.ThreadUtil;
 
 public class FileSelectionFactory {
 
-	public static File GetFile(File start, boolean save,ExtensionFilter... filter) {
+	private FileSelectionFactory() {
+	}
+
+	public static File GetFile(File start, boolean save, ExtensionFilter... filter) {
 		class fileHolder{
 			private boolean done=false;
 			private File file=null;

--- a/src/main/java/com/neuronrobotics/nrconsole/util/NRConsoleDocumentationFactory.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/util/NRConsoleDocumentationFactory.java
@@ -23,6 +23,9 @@ import com.neuronrobotics.sdk.common.Log;
  */
 public class NRConsoleDocumentationFactory {
 
+	private NRConsoleDocumentationFactory() {
+	}
+
 	public static URI getDocumentationURL(Object input) {
 
 		try {

--- a/src/main/java/com/neuronrobotics/nrconsole/util/PromptForGit.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/util/PromptForGit.java
@@ -11,7 +11,10 @@ import javafx.scene.control.ChoiceDialog;
 import javafx.scene.control.TextInputDialog;
 
 public class PromptForGit {
-	public static void prompt(String purpose,String defaultID, IGistPromptCompletionListener listener){
+	private PromptForGit() {
+	}
+
+	public static void prompt(String purpose, String defaultID, IGistPromptCompletionListener listener){
 		Platform.runLater(() -> {
 			TextInputDialog dialog = new TextInputDialog(defaultID);
 			dialog.setTitle(purpose);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.