### PR TITLE
Primitives should not be boxed just for "String" conversion

### DIFF
--- a/src/main/java/com/neuronrobotics/bowlerstudio/creature/EngineeringUnitsSliderWidget.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/creature/EngineeringUnitsSliderWidget.java
@@ -111,7 +111,7 @@ public class EngineeringUnitsSliderWidget extends GridPane implements ChangeList
 	
 	public  String getFormatted(double value){
 		if(intCast)
-			return ""+((int)value);
+			return String.valueOf((int)value);
 	    return String.format("%4.3f%n", (double)value);
 	}
 	public IOnEngineeringUnitsChange getListener() {

--- a/src/main/java/com/neuronrobotics/bowlerstudio/creature/JogWidget.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/creature/JogWidget.java
@@ -42,7 +42,7 @@ public class JogWidget extends GridPane implements ITaskSpaceUpdateListenerNR, I
 	Button nz = new Button("",AssetFactory.loadIcon("Minuz-Z.png"));
 	Button home = new Button("",AssetFactory.loadIcon("Home.png"));
 	Button game = new Button("Add Game Controller",AssetFactory.loadIcon("Add-Game-Controller.png"));
-	TextField increment=new TextField(new Double(defauletSpeed).toString());
+	TextField increment=new TextField(Double.toString(defauletSpeed));
 	TextField sec=new TextField(".01");
 	private TransformWidget transform;
 	BowlerJInputDevice gameController=null;
@@ -325,7 +325,7 @@ public class JogWidget extends GridPane implements ITaskSpaceUpdateListenerNR, I
 					}catch(Exception e){
 						inc=defauletSpeed;
 						Platform.runLater(() -> {
-							increment.setText(new Double(defauletSpeed).toString());
+							increment.setText(Double.toString(defauletSpeed));
 						});
 					}
 					//double rxl=0;

--- a/src/main/java/com/neuronrobotics/bowlerstudio/creature/LinkConfigurationWidget.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/creature/LinkConfigurationWidget.java
@@ -353,7 +353,7 @@ public class LinkConfigurationWidget extends GridPane {
 
 		final ComboBox<String> channel = new ComboBox<String>();
 		for (int i=0;i<24;i++) {
-			channel.getItems().add(new Integer(i).toString());
+			channel.getItems().add(Integer.toString(i));
 		}
 		channel.setOnAction(new EventHandler<ActionEvent>() {
 			

--- a/src/main/java/com/neuronrobotics/bowlerstudio/creature/PrinterConfiguration.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/creature/PrinterConfiguration.java
@@ -89,18 +89,18 @@ public class PrinterConfiguration extends JPanel {
 		if(NRPrinter.class.isInstance(p)){
 			this.printer = (NRPrinter)p;
 			state = printer.getStateBasedControllerConfiguration();
-			kp.setText(new Double(state.getkP()).toString());
-			ki.setText(new Double(state.getkI()).toString());
-			kd.setText(new Double(state.getkD()).toString());
-			vkp.setText(new Double(state.getvKP()).toString());
-			vkd.setText(new Double(state.getvKD()).toString());
-			mmPos.setText(new Double(state.getMmPositionResolution()).toString());
-			maxVel.setText(new Double(state.getMaximumMMperSec()).toString());
-			baseRad.setText(new Double(state.getBaseRadius()).toString());
-			EErad.setText(new Double(state.getEndEffectorRadius()).toString());
-			maxz.setText(new Double(state.getMaxZ()).toString());
-			minz.setText(new Double(state.getMinZ()).toString());
-			rodlen.setText(new Double(state.getRodLength()).toString());
+			kp.setText(Double.toString(state.getkP()));
+			ki.setText(Double.toString(state.getkI()));
+			kd.setText(Double.toString(state.getkD()));
+			vkp.setText(Double.toString(state.getvKP()));
+			vkd.setText(Double.toString(state.getvKD()));
+			mmPos.setText(Double.toString(state.getMmPositionResolution()));
+			maxVel.setText(Double.toString(state.getMaximumMMperSec()));
+			baseRad.setText(Double.toString(state.getBaseRadius()));
+			EErad.setText(Double.toString(state.getEndEffectorRadius()));
+			maxz.setText(Double.toString(state.getMaxZ()));
+			minz.setText(Double.toString(state.getMinZ()));
+			rodlen.setText(Double.toString(state.getRodLength()));
 			hardPos.setSelected(state.isUseHardPositioning());
 			add(controls,"wrap");
 		}

--- a/src/main/java/com/neuronrobotics/bowlerstudio/tabs/DyIOPanel.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/tabs/DyIOPanel.java
@@ -213,13 +213,13 @@ public class DyIOPanel  implements Initializable {
 			ObservableList<String> items = FXCollections.observableArrayList();
 			DyIOChannel chan = dyio.getChannel(index);
 			displayFlash.add(new Boolean(true));
-			Platform.runLater(()->channelValue.get(index).setText(new Integer(chan.getValue()).toString()));
+			Platform.runLater(()->channelValue.get(index).setText(Integer.toString(chan.getValue())));
 			chan.addChannelEventListener(e -> {
 				// set the value label text
 				if(displayFlash.get(index)){
 					displayFlash.set(index, false);
 					Platform.runLater(()->{
-							channelValue.get(index).setText(new Integer(e.getValue()).toString());
+							channelValue.get(index).setText(Integer.toString(e.getValue()));
 							channelButtonSelectors.get(index).setImage(BowlerStudioResourceFactory.getChanUpdate());
 							FxTimer.runLater(
 									Duration.ofMillis(200) ,() -> {

--- a/src/main/java/com/neuronrobotics/bowlerstudio/tabs/DyIOchannelWidget.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/tabs/DyIOchannelWidget.java
@@ -47,7 +47,7 @@ public class DyIOchannelWidget {
 		public void changed(ObservableValue<? extends Number> ov,
 				Number old_val, Number new_val) {
 			int newVal = new_val.intValue();
-			chanValue.setText(new Integer(newVal).toString());
+			chanValue.setText(Integer.toString(newVal));
 			if(currentMode==DyIOChannelMode.SERVO_OUT ){
 				if(timeSlider.getValue()>.1){
 					//servo should only set on release when time is defined
@@ -89,8 +89,8 @@ public class DyIOchannelWidget {
 			this.channel = c;
 			startTime=System.currentTimeMillis();
 			setMode( channel.getMode());
-			Platform.runLater(()->deviceNumber.setText(new Integer(channel.getChannelNumber()).toString()));
-			Platform.runLater(()->chanValue.setText(new Integer(channel.getValue()).toString()));
+			Platform.runLater(()->deviceNumber.setText(Integer.toString(channel.getChannelNumber())));
+			Platform.runLater(()->chanValue.setText(Integer.toString(channel.getValue())));
 			Platform.runLater(()->secondsLabel.setText(String.format("%.2f", 0.0)));
 			Platform.runLater(()->positionSlider.setValue(channel.getValue()));
 			Platform.runLater(()->graphValueAxis.setAnimated(false));
@@ -99,7 +99,7 @@ public class DyIOchannelWidget {
 			
 			positionSlider.valueChangingProperty().addListener((ChangeListener<Boolean>) (observable, oldValue, newValue) -> {
 	
-				chanValue.setText(new Integer((int) positionSlider.getValue()).toString());
+				chanValue.setText(Integer.toString((int) positionSlider.getValue()));
 				if(currentMode==DyIOChannelMode.SERVO_OUT && timeSlider.getValue()>.1){
 					new Thread(){
 						public void run(){
@@ -153,7 +153,7 @@ public class DyIOchannelWidget {
 			Data<Integer, Integer> newChart = new XYChart.Data<Integer, Integer>(
 	        		(int) (startTime-System.currentTimeMillis()),
 	        		current);
-			Platform.runLater(()->chanValue.setText(new Integer(current).toString()));
+			Platform.runLater(()->chanValue.setText(Integer.toString(current)));
 				if(!positionSlider.isValueChanging()){// only updae the slider position if the user is not sliding it
 					Platform.runLater(()->{
 						if(positionSlider==null)

--- a/src/main/java/com/neuronrobotics/graphing/GraphingWindow.java
+++ b/src/main/java/com/neuronrobotics/graphing/GraphingWindow.java
@@ -114,7 +114,7 @@ public class GraphingWindow extends JPanel {
 				}
 				
 				axis.setFixedAutoRange(value);
-				length.setText(value + "");
+				length.setText(String.valueOf(value));
 				scale.setValue(value);
 				
 				invalidate();
@@ -160,7 +160,7 @@ public class GraphingWindow extends JPanel {
 		
         axis.setAutoRange(true);
         axis.setFixedAutoRange(scale.getValue());  
-        length.setText("" + scale.getValue());
+        length.setText(String.valueOf(scale.getValue()));
 		//invalidate();
 		repaint();
 	}
@@ -176,7 +176,7 @@ public class GraphingWindow extends JPanel {
         double sLower =loc-(scale.getValue()/2);
         double sUpper =loc+(scale.getValue()/2);
         axis.setRange(sLower, sUpper);
-        length.setText("" + scale.getValue());
+        length.setText(String.valueOf(scale.getValue()));
 		//invalidate();
 		//repaint();
 	}

--- a/src/main/java/com/neuronrobotics/nrconsole/plugin/BowlerCam/BowlerCamPanel.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/plugin/BowlerCam/BowlerCamPanel.java
@@ -77,13 +77,13 @@ public class BowlerCamPanel extends JPanel implements IWebcamImageListener {
 		controls.add(new JLabel("Threshhold"),"wrap");
 		controls.add(threshhold);
 		controls.add(thr,"wrap");
-		thr.setText(new Integer(threshhold.getValue()).toString());
+		thr.setText(Integer.toString(threshhold.getValue()));
 		controls.add(within,"wrap");
 		within.setSelected(true);
 		
 		controls.add(new JLabel("Image Scale"));
 		controls.add(scale,"wrap");
-		scale.setText(new Double(scaleSet).toString());
+		scale.setText(Double.toString(scaleSet));
 		
 		min.setText("5");
 		max.setText("100000");
@@ -123,7 +123,7 @@ public class BowlerCamPanel extends JPanel implements IWebcamImageListener {
 	
 	
 	private void displayImage() {
-		thr.setText(new Integer(threshhold.getValue()).toString());
+		thr.setText(Integer.toString(threshhold.getValue()));
 		target.getColor();
 		if(scaleSet != Double.parseDouble(scale.getText())){
 			//System.out.println("Resetting scale : "+scale.getText());

--- a/src/main/java/com/neuronrobotics/nrconsole/plugin/BowlerCam/RGBSlider.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/plugin/BowlerCam/RGBSlider.java
@@ -73,9 +73,9 @@ public class RGBSlider extends JPanel {
 		getColor();
 	}
 	public Color getColor(){
-		rl.setText(new Integer(r.getValue()).toString());
-		gl.setText(new Integer(g.getValue()).toString());
-		bl.setText(new Integer(b.getValue()).toString());
+		rl.setText(Integer.toString(r.getValue()));
+		gl.setText(Integer.toString(g.getValue()));
+		bl.setText(Integer.toString(b.getValue()));
 		Color now =new Color(r.getValue(),g.getValue(),b.getValue());
 		c.setColor(now);
 		setBackground(now);

--- a/src/main/java/com/neuronrobotics/nrconsole/plugin/DyIO/Secheduler/SchedulerControlBar.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/plugin/DyIO/Secheduler/SchedulerControlBar.java
@@ -170,7 +170,7 @@ public class SchedulerControlBar extends JPanel implements ISchedulerListener {
 	}
 	
 	private void setTrackLegnth(int ms){
-		length.setText(new Double(((double)ms)/1000.0).toString());
+		length.setText(Double.toString(((double)ms)/1000.0));
 		setBounds(ms);
 	}
 	

--- a/src/main/java/com/neuronrobotics/nrconsole/plugin/DyIO/Secheduler/ServoOutputScheduleChannelUI.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/plugin/DyIO/Secheduler/ServoOutputScheduleChannelUI.java
@@ -160,8 +160,8 @@ public class ServoOutputScheduleChannelUI extends JPanel implements IServoPositi
 			ex.printStackTrace();
 		}
 		//recordConfig.setVisible(record.isSelected());
-		zero.setText(new Integer(getChannel().getInputCenter()).toString());
-		scale.setText(new Double(getChannel().getInputScale()).toString());
+		zero.setText(Integer.toString(getChannel().getInputCenter()));
+		scale.setText(Double.toString(getChannel().getInputScale()));
 		setScaleingInfo();
 	}
 	private void setScaleingInfo() {

--- a/src/main/java/com/neuronrobotics/nrconsole/plugin/PID/AdvancedPIDWidget.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/plugin/PID/AdvancedPIDWidget.java
@@ -21,16 +21,16 @@ public class AdvancedPIDWidget extends JPanel{
 	private StepLoop looper=null;
 	private SineTrack siner=null;
 	
-	private JTextField loopStart=new JTextField(new Double(0).toString(),5);
-	private JTextField loopMiddle=new JTextField(new Double(100).toString(),5);
-	private JTextField loopEnd=new JTextField(new Double(200).toString(),5);
-	private JTextField loopIterations=new JTextField(new Double(20).toString(),5);
-	private JTextField loopTime=new JTextField(new Double(.5).toString(),5);
+	private JTextField loopStart=new JTextField(Double.toString(0),5);
+	private JTextField loopMiddle=new JTextField(Double.toString(100),5);
+	private JTextField loopEnd=new JTextField(Double.toString(200),5);
+	private JTextField loopIterations=new JTextField(Double.toString(20),5);
+	private JTextField loopTime=new JTextField(Double.toString(.5),5);
 	private JButton  runLoop = new JButton("Run Step Loop");
 	private JButton  stopLoop = new JButton("Stop Loop");
 	private JButton  runSin = new JButton("Run Sin wave");
 	private JButton  jogP = new JButton("Jog+");
-	private JTextField jogV=new JTextField(new Integer(100).toString(),5);
+	private JTextField jogV=new JTextField(Integer.toString(100),5);
 	private JButton  jogM = new JButton("Jog-");
 	
 	public AdvancedPIDWidget(PIDControlWidget pid) {

--- a/src/main/java/com/neuronrobotics/nrconsole/plugin/PID/PIDControlWidget.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/plugin/PID/PIDControlWidget.java
@@ -40,7 +40,7 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 	private JPanel latchPanel = new JPanel(new MigLayout());
 	private JButton  pidSet = new JButton("Configure");
 	private JButton  pidStop = new JButton("Stop");
-	private JTextField setpoint=new JTextField(new Double(0).toString(),5);
+	private JTextField setpoint=new JTextField(Double.toString(0),5);
 	private JButton  setSetpoint = new JButton("Set Setpoint");
 	private JButton  zero = new JButton("Zero PID");
 	private JLabel   currentPos = new JLabel("0");
@@ -64,7 +64,7 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 //			Log.enableDebugPrint(true);
 		setBorder(BorderFactory.createRaisedBevelBorder());
 		tab.getPidDevice().addPIDEventListener(this);
-		currentPos.setText(new Integer(startValue).toString());
+		currentPos.setText(Integer.toString(startValue));
 		setpointValue=startValue;
 		setPositionDisplay(startValue);
 		setLayout(new MigLayout("", "[]", "[][][]"));
@@ -80,56 +80,56 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 				try{
 					p=Double.parseDouble(kp.getText());
 				}catch(Exception e){
-					kp.setText(new Double(1).toString());
+					kp.setText(Double.toString(1));
 					showMessage( "Bad PID values, resetting.",e);
 					return;
 				}
 				try{
 					i=Double.parseDouble(ki.getText());
 				}catch(Exception e){
-					ki.setText(new Double(0).toString());
+					ki.setText(Double.toString(0));
 					showMessage( "Bad PID values, resetting.",e);
 					return;
 				}
 				try{
 					d=Double.parseDouble(kd.getText());
 				}catch(Exception e){
-					kd.setText(new Double(0).toString());
+					kd.setText(Double.toString(0));
 					showMessage( "Bad PID values, resetting.",e);
 					return;
 				}
 				try{
 					l=Double.parseDouble(indexLatch.getText());
 				}catch(Exception e){
-					indexLatch.setText(new Double(0).toString());
+					indexLatch.setText(Double.toString(0));
 					showMessage( "Bad PID values, resetting.",e);
 					return;
 				}
 				try{
 					vp=Double.parseDouble(vkp.getText());
 				}catch(Exception e){
-					vkp.setText(new Double(.1).toString());
+					vkp.setText(Double.toString(.1));
 					showMessage( "Bad PID values, resetting.",e);
 					return;
 				}
 				try{
 					vd=Double.parseDouble(vkd.getText());
 				}catch(Exception e){
-					vkd.setText(new Double(0).toString());
+					vkd.setText(Double.toString(0));
 					showMessage( "Bad PID values, resetting.",e);
 					return;
 				}
 				try{
 					up=Double.parseDouble(upHys.getText());
 				}catch(Exception e){
-					upHys.setText(new Double(0).toString());
+					upHys.setText(Double.toString(0));
 					showMessage( "Bad PID values, resetting.",e);
 					return;
 				}
 				try{
 					low=Double.parseDouble(lowHys.getText());
 				}catch(Exception e){
-					lowHys.setText(new Double(0).toString());
+					lowHys.setText(Double.toString(0));
 					showMessage( "Bad PID values, resetting.",e);
 					return;
 				}
@@ -155,7 +155,7 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 				ResetPIDChannel();
 				int val = GetPIDPosition();
 				setSetpoint(val);
-				currentPos.setText(new Integer(val).toString());
+				currentPos.setText(Integer.toString(val));
 			}
 		});
 		
@@ -172,7 +172,7 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 			}
 		});
 		
-		setpoint.setText(new Integer(startValue).toString());
+		setpoint.setText(Integer.toString(startValue));
 		setpoint.addActionListener(this);
 		setSetpoint.addActionListener(this);
 		
@@ -269,16 +269,16 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 	private void populatePID() {
 		advanced = new  AdvancedPIDWidget(this);
 		getPIDConfiguration();
-		kp.setText(new Double(getPIDConfiguration().getKP()).toString());
-		ki.setText(new Double(getPIDConfiguration().getKI()).toString());
-		kd.setText(new Double(getPIDConfiguration().getKD()).toString());
+		kp.setText(Double.toString(getPIDConfiguration().getKP()));
+		ki.setText(Double.toString(getPIDConfiguration().getKI()));
+		kd.setText(Double.toString(getPIDConfiguration().getKD()));
 		
-		upHys.setText(new Double(getPIDConfiguration().getUpperHystersys()).toString());
-		lowHys.setText(new Double(getPIDConfiguration().getLowerHystersys()).toString());
+		upHys.setText(Double.toString(getPIDConfiguration().getUpperHystersys()));
+		lowHys.setText(Double.toString(getPIDConfiguration().getLowerHystersys()));
 		
-		vkp.setText(new Double(getPDVelocityConfiguration().getKP()).toString());
-		vkd.setText(new Double(getPDVelocityConfiguration().getKD()).toString());
-		indexLatch.setText(new Double(getPIDConfiguration().getIndexLatch()).toString());
+		vkp.setText(Double.toString(getPDVelocityConfiguration().getKP()));
+		vkd.setText(Double.toString(getPDVelocityConfiguration().getKD()));
+		indexLatch.setText(Double.toString(getPIDConfiguration().getIndexLatch()));
 	    useLatch.setSelected(getPIDConfiguration().isUseLatch());
 	    stopOnLatch.setSelected(getPIDConfiguration().isStopOnIndex());
 		inverted.setSelected(getPIDConfiguration().isInverted());
@@ -348,7 +348,7 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 	public void setInternalSetpoint(int setPoint){
 		//System.out.println("Setting setpoint on group="+getGroup()+" value="+setPoint);
 		setpointValue=setPoint;
-		setpoint.setText(new Integer(setPoint).toString());
+		setpoint.setText(Integer.toString(setPoint));
 		graphVals();
 		getPidStop().setEnabled(true);
 	}
@@ -380,7 +380,7 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 	}
 
 	public void setPositionDisplay(int positionValue) {
-		currentPos.setText(new Integer(positionValue).toString());
+		currentPos.setText(Integer.toString(positionValue));
 		this.positionValue = positionValue;
 		graphVals();
 	}
@@ -416,7 +416,7 @@ public class PIDControlWidget extends JPanel implements IPIDEventListener,Action
 		try{
 			setSetpoint(getSetPoint());
 		}catch(Exception e){
-			setpoint.setText(new Integer(0).toString());
+			setpoint.setText(Integer.toString(0));
 			return;
 		}
 	}

--- a/src/main/java/com/neuronrobotics/pidsim/PIDConstantsDialog.java
+++ b/src/main/java/com/neuronrobotics/pidsim/PIDConstantsDialog.java
@@ -34,9 +34,9 @@ public class PIDConstantsDialog extends JPanel {
 		add(iData,"wrap");
 		add(new JLabel("Kd"));
 		add(dData,"wrap");
-		pData.setText(new Double(getKp()).toString());
-		iData.setText(new Double(getKi()).toString());
-		dData.setText(new Double(getKd()).toString());
+		pData.setText(Double.toString(getKp()));
+		iData.setText(Double.toString(getKi()));
+		dData.setText(Double.toString(getKd()));
 		set.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.