### PR TITLE
"entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/src/main/java/com/neuronrobotics/bowlerstudio/MainController.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/MainController.java
@@ -334,9 +334,9 @@ public class MainController implements Initializable {
 					
 					@SuppressWarnings("unchecked")
 					HashMap<String,HashMap<String,Object>> map = (HashMap<String, HashMap<String, Object>>) ScriptingEngine.inlineFileScriptRun(f, null);
-					for(String menuTitle:map.keySet()){
-						HashMap<String,Object> script = map.get(menuTitle);
-						MenuItem item = new MenuItem(menuTitle);
+					for(Map.Entry<String, HashMap<String, Object>> entry : map.entrySet()){
+						HashMap<String,Object> script = entry.getValue();
+						MenuItem item = new MenuItem(entry.getKey());
 						item.setOnAction(event -> {
 							loadMobilebaseFromGit(	(String)script.get("scriptGit"),
 													(String)script.get("scriptFile"));
@@ -493,13 +493,13 @@ public class MainController implements Initializable {
 						// Now load the users GIT repositories
 						// github.getMyOrganizations();
 						Map<String, GHOrganization> orgs = github.getMyOrganizations();
-						for (String org : orgs.keySet()) {
+						for (Map.Entry<String, GHOrganization> entry : orgs.entrySet()) {
 							// System.out.println("Org: "+org);
-							Menu OrgItem = new Menu(org);
-							GHOrganization ghorg = orgs.get(org);
+							Menu OrgItem = new Menu(entry.getKey());
+							GHOrganization ghorg = entry.getValue();
 							Map<String, GHRepository> repos = ghorg.getRepositories();
-							for (String orgRepo : repos.keySet()) {
-								setUpRepoMenue(OrgItem, repos.get(orgRepo));
+							for (Map.Entry<String, GHRepository> entry1 : repos.entrySet()) {
+								setUpRepoMenue(OrgItem, entry1.getValue());
 							}
 							Platform.runLater(() -> {
 								myOrganizations.getItems().add(OrgItem);
@@ -509,8 +509,8 @@ public class MainController implements Initializable {
 						// Repos I own
 						Map<String, GHRepository> myPublic = self.getAllRepositories();
 						HashMap<String, Menu> myownerMenue = new HashMap<>();
-						for (String myRepo : myPublic.keySet()) {
-							GHRepository g = myPublic.get(myRepo);
+						for (Map.Entry<String, GHRepository> entry : myPublic.entrySet()) {
+							GHRepository g = entry.getValue();
 							if (myownerMenue.get(g.getOwnerName()) == null) {
 								myownerMenue.put(g.getOwnerName(), new Menu(g.getOwnerName()));
 								Platform.runLater(() -> {

--- a/src/main/java/com/neuronrobotics/bowlerstudio/assets/AssetFactory.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/assets/AssetFactory.java
@@ -106,9 +106,9 @@ public class AssetFactory {
 			org.kohsuke.github.GitHub github = ScriptingEngine.getGithub();
 			GHMyself self = github.getMyself();
 			Map<String, GHRepository> myPublic = self.getAllRepositories();
-			for (String myRepo :myPublic.keySet()){
-				if(myRepo.contentEquals(repo)){
-					GHRepository ghrepo= myPublic.get(myRepo);
+			for (Map.Entry<String, GHRepository> entry : myPublic.entrySet()){
+				if(entry.getKey().contentEquals(repo)){
+					GHRepository ghrepo= entry.getValue();
 					String myAssets = ghrepo.getGitTransportUrl().replaceAll("git://", "https://");
 					System.out.println("Using my version of assets: "+myAssets);
 					setGitSource(myAssets);

--- a/src/main/java/com/neuronrobotics/bowlerstudio/creature/LinkConfigurationWidget.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/creature/LinkConfigurationWidget.java
@@ -2,6 +2,7 @@ package com.neuronrobotics.bowlerstudio.creature;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.kohsuke.github.GHRepository;
@@ -535,12 +536,12 @@ public class LinkConfigurationWidget extends GridPane {
 			HashMap<String,TextField> valueFields=new HashMap<String,TextField> ();
 			
 			int row=0;
-			for(String s: startingConf.keySet()){
+			for(Map.Entry<String, Object> entry : startingConf.entrySet()){
 				TextField username = new TextField();
-	    		username.setText(startingConf.get(s).toString());
-	    		grid.add(new Label(s), 0, row);
+	    		username.setText(entry.getValue().toString());
+	    		grid.add(new Label(entry.getKey()), 0, row);
 	    		grid.add(username, 1, row);
-	    		valueFields.put(s, username);
+	    		valueFields.put(entry.getKey(), username);
 	    		row++;
 			}
 
@@ -550,9 +551,9 @@ public class LinkConfigurationWidget extends GridPane {
 			if(r.get() == ButtonType.OK){
 				new Thread(){
 						public void run(){
-				    		for(String s:valueFields.keySet()){
+				    		for(Map.Entry<String, TextField> entry : valueFields.entrySet()){
 				    			try {
-									Vitamins.setParameter(type,id,s,(Object)valueFields.get(s).getText());
+									Vitamins.setParameter(type,id, entry.getKey(),(Object) entry.getValue().getText());
 								} catch (Exception e) {
 									// TODO Auto-generated catch block
 									e.printStackTrace();

--- a/src/main/java/com/neuronrobotics/bowlerstudio/creature/MobleBaseMenueFactory.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/creature/MobleBaseMenueFactory.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
@@ -391,13 +392,13 @@ public class MobleBaseMenueFactory {
 				}
 			}
 		}
-		for (String key : deviceMap.keySet()) {
-			HashMap<Integer, Boolean> chans = deviceMap.get(key);
+		for (Map.Entry<String, HashMap<Integer, Boolean>> entry : deviceMap.entrySet()) {
+			HashMap<Integer, Boolean> chans = entry.getValue();
 			for (int i = 0; i < 24; i++) {
 
 				if (chans.get(i) == null) {
-					System.err.println("Channel free: " + i + " on device " + key);
-					confOfChannel.setDeviceScriptingName(key);
+					System.err.println("Channel free: " + i + " on device " + entry.getKey());
+					confOfChannel.setDeviceScriptingName(entry.getKey());
 					confOfChannel.setHardwareIndex(i);
 					return;
 				}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.