### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/src/main/java/com/neuronrobotics/bowlerstudio/robots/FormacarumRover.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/robots/FormacarumRover.java
@@ -147,7 +147,7 @@ public class FormacarumRover extends AbstractRobotDrive {
 		//Log.enableDebugPrint(true);
 		
 		drive.ResetPIDChannel(0);
-		ThreadUtil.wait((200));
+		ThreadUtil.wait(200);
 		//Log.enableDebugPrint(false);
 	}
 	

--- a/src/main/java/com/neuronrobotics/bowlerstudio/threed/BowlerStudio3dEngine.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/threed/BowlerStudio3dEngine.java
@@ -867,7 +867,7 @@ public class BowlerStudio3dEngine extends JFXPanel {
 
 			@Override
 			public void handle(ScrollEvent t) {
-				if (ScrollEvent.SCROLL == (t).getEventType()) {
+				if (ScrollEvent.SCROLL == t.getEventType()) {
 
 //					double zoomFactor = (t.getDeltaY());
 //

--- a/src/main/java/com/neuronrobotics/bowlerstudio/threed/MobileBaseCadManager.java
+++ b/src/main/java/com/neuronrobotics/bowlerstudio/threed/MobileBaseCadManager.java
@@ -378,7 +378,7 @@ public class MobileBaseCadManager {
 	}
 	private void setDefaultLinkLevelCadEngine() throws Exception {
 		String[] cad;
-			cad = (base).getGitCadEngine();
+			cad = base.getGitCadEngine();
 
 		if (cadEngine == null) {
 			setGitCadEngine(cad[0], cad[1], base);

--- a/src/main/java/com/neuronrobotics/nrconsole/plugin/bootloader/BootloaderPanel.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/plugin/bootloader/BootloaderPanel.java
@@ -132,7 +132,7 @@ public class BootloaderPanel extends AbstractBowlerStudioTab implements ActionLi
 				}
 				
 				String path = f.getAbsolutePath().toLowerCase();
-				if ((path.endsWith("xml") && (path.charAt(path.length() - 3)) == '.')) {
+				if (path.endsWith("xml") && path.charAt(path.length() - 3) == '.') {
 					return true;
 				}
 				

--- a/src/main/java/com/neuronrobotics/nrconsole/plugin/bootloader/gui/NR_Bootloader_GUI.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/plugin/bootloader/gui/NR_Bootloader_GUI.java
@@ -185,7 +185,7 @@ public class NR_Bootloader_GUI implements ActionListener {
 				}
 				
 				String path = f.getAbsolutePath().toLowerCase();
-				if ((path.endsWith("xml") && (path.charAt(path.length() - 3)) == '.')) {
+				if (path.endsWith("xml") && path.charAt(path.length() - 3) == '.') {
 					return true;
 				}
 				

--- a/src/main/java/com/neuronrobotics/nrconsole/util/GCodeFilter.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/util/GCodeFilter.java
@@ -14,10 +14,10 @@ public class GCodeFilter extends FileFilter {
 			return true;
 		}
 		String path = f.getAbsolutePath().toLowerCase();
-		if ((path.endsWith("gcode") && (path.charAt(path.length() - 5)) == '.')) {
+		if (path.endsWith("gcode") && path.charAt(path.length() - 5) == '.') {
 			return true;
 		}
-		if ((path.endsWith("ngc") && (path.charAt(path.length() - 3)) == '.')) {
+		if (path.endsWith("ngc") && path.charAt(path.length() - 3) == '.') {
 			return true;
 		}
 		return f.getName().matches(".+\\.gcode$") || f.getName().matches(".+\\.ngc$");

--- a/src/main/java/com/neuronrobotics/nrconsole/util/Mp3Filter.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/util/Mp3Filter.java
@@ -14,7 +14,7 @@ public class Mp3Filter extends FileFilter {
 			return true;
 		}
 		String path = f.getAbsolutePath().toLowerCase();
-		if ( (path.endsWith("wav")&& (path.charAt(path.length() - 3)) == '.')) {
+		if (path.endsWith("wav")&& path.charAt(path.length() - 3) == '.') {
 			return true;
 		}
 		return f.getName().matches(".+\\.wav$");

--- a/src/main/java/com/neuronrobotics/nrconsole/util/StlFilter.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/util/StlFilter.java
@@ -14,7 +14,7 @@ public class StlFilter extends FileFilter {
 			return true;
 		}
 		String path = f.getAbsolutePath().toLowerCase();
-		if ((path.toLowerCase().endsWith("stl") && (path.charAt(path.length() - 3)) == '.')) {
+		if (path.toLowerCase().endsWith("stl") && path.charAt(path.length() - 3) == '.') {
 			return true;
 		}
 

--- a/src/main/java/com/neuronrobotics/nrconsole/util/XmlFilter.java
+++ b/src/main/java/com/neuronrobotics/nrconsole/util/XmlFilter.java
@@ -15,7 +15,7 @@ public class XmlFilter extends FileFilter {
 			return true;
 		}
 		String path = f.getAbsolutePath().toLowerCase();
-		if ((path.endsWith("xml") && (path.charAt(path.length() - 3)) == '.')) {
+		if (path.endsWith("xml") && path.charAt(path.length() - 3) == '.') {
 			return true;
 		}
 		return f.getName().matches(".+\\.xml$");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.